### PR TITLE
support env based coin table configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const DocumentDB = new AWS.DynamoDB.DocumentClient();
 const slack = require('serverless-slack');
 const DynamoDBService = require('./services/dynamodb');
 
-const CoinsService = new DynamoDBService(DocumentDB, 'Coins');
+const CoinsService = new DynamoDBService(DocumentDB, process.env.COINS_TABLE_NAME);
 
 const GrantCoinsCommand = require('./commands/grantCoins');
 const ListCoinsCommand = require('./commands/listCoins');


### PR DESCRIPTION
Use the `COINS_TABLE_NAME` environment variable instead of hard-coding the coin table name.

Issues: #47